### PR TITLE
Message time fixes and delinquent message actions

### DIFF
--- a/cmd/runTests.go
+++ b/cmd/runTests.go
@@ -7,12 +7,13 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"time"
+
 	"github.com/hyperledger/firefly-perf-cli/internal/conf"
 	"github.com/hyperledger/firefly-perf-cli/internal/perf"
 	"github.com/hyperledger/firefly-perf-cli/internal/types"
 	"github.com/hyperledger/firefly/pkg/fftypes"
-	"io/ioutil"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -91,6 +92,7 @@ func init() {
 	runTestsCmd.Flags().StringVarP(&runTestsConfig.ContractOptions.Channel, "channel", "", "", "Fabric channel for custom contract")
 	runTestsCmd.Flags().StringVarP(&runTestsConfig.ContractOptions.Chaincode, "chaincode", "", "", "Chaincode name for custom contract")
 	runTestsCmd.Flags().StringVarP(&runTestsConfig.StackJSONPath, "stackJSON", "s", "", "Path to stack.json file that describes the network to test")
+	runTestsCmd.Flags().StringVarP(&runTestsConfig.DelinquentAction, "delinquent", "", "exit", "Action to take when delinquent messages are detected. Valid options: [exit log]")
 }
 
 func validateCommands(cmds []string) error {

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -35,6 +35,7 @@ type PerfConfig struct {
 	Workers          int
 	NodeURLs         []string
 	StackJSONPath    string
+	DelinquentAction string
 }
 
 type FireFlyWsConf struct {
@@ -76,6 +77,13 @@ var (
 	PerfBlobBroadcast fftypes.FFEnum = "blob_broadcast"
 	// PerfBlobBroadcast broadcasts a blob
 	PerfBlobPrivateMsg fftypes.FFEnum = "blob_private"
+)
+
+var (
+	// DelinquentActionExit causes ffperf to exit after detecting delinquent messages
+	DelinquentActionExit fftypes.FFEnum = "exit"
+	// DelinquentActionLog causes ffperf to log and move on after delinquent messages
+	DelinquentActionLog fftypes.FFEnum = "log"
 )
 
 var ValidPerfCommands = map[string]fftypes.FFEnum{

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -447,7 +447,7 @@ func (pr *perfRunner) getDelinquentMsgs() {
 	}
 
 	log.Warnf("Delinquent Messages:\n%s", string(dw))
-	if len(delinquentMsgs) > 0 {
+	if len(delinquentMsgs) > 0 && pr.cfg.DelinquentAction == conf.DelinquentActionExit.String() {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This PR adds a couple of fixes for tracking the time of messages and also adds a command line flag to exit the test runner if it detects delinquent messages. 

**The default behavior is to exit the test.** If you wish to simply log the delinquent messages and continue testing, use the `--delinquent log` flag.