### PR TITLE
Add heartbeating to FF perf CLI

### DIFF
--- a/cmd/runTests.go
+++ b/cmd/runTests.go
@@ -33,9 +33,10 @@ Executes the provided list of tests against a FireFly node to generate synthetic
 			WSPath:                 "/ws",
 			ReadBufferSize:         16000,
 			WriteBufferSize:        16000,
-			InitialDelay:           250000000,
-			MaximumDelay:           30000000000,
+			InitialDelay:           250 * time.Millisecond,
+			MaximumDelay:           30 * time.Second,
 			InitialConnectAttempts: 5,
+			HeartbeatInterval:      5 * time.Second,
 		}
 
 		if perfRunner == nil {

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -46,6 +46,7 @@ type FireFlyWsConf struct {
 	InitialDelay           time.Duration `mapstructure:"initialDelay"`
 	MaximumDelay           time.Duration `mapstructure:"maximumDelay"`
 	InitialConnectAttempts int           `mapstructure:"initialConnectAttempts"`
+	HeartbeatInterval      time.Duration `mapstructure:"heartbeatInterval"`
 }
 
 func GenerateWSConfig(nodeURL string, conf *FireFlyWsConf) *wsclient.WSConfig {
@@ -59,6 +60,7 @@ func GenerateWSConfig(nodeURL string, conf *FireFlyWsConf) *wsclient.WSConfig {
 		InitialDelay:           conf.InitialDelay,
 		MaximumDelay:           conf.MaximumDelay,
 		InitialConnectAttempts: conf.InitialConnectAttempts,
+		HeartbeatInterval:      conf.HeartbeatInterval,
 	}
 }
 


### PR DESCRIPTION
We saw a case where FireFly got an `EOF` on the WebSocket from the perf CLI:

```
[2022-03-29T17:48:00.375Z] ERROR node_0: Read failed: websocket: close 1006 (abnormal closure): unexpected EOF websocket=8a267d00-60bb-479f-b5d0-870718776047
```

... but there were no corresponding errors on the perf CLI side. I found that heartbeats were not configured.