### PR TITLE
remove token pool timeout

### DIFF
--- a/internal/perf/token_pool.go
+++ b/internal/perf/token_pool.go
@@ -32,7 +32,6 @@ func (pr *perfRunner) CreateTokenPool() error {
 	}
 
 	res, err := pr.client.R().
-		SetHeader("Request-Timeout", "15s").
 		SetBody(&body).
 		Post("/api/v1/namespaces/default/tokens/pools?confirm=true")
 


### PR DESCRIPTION
request will now use firefly default timeout of 120s