### PR TITLE
Post test balance check

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The `ffperf` tool registers the following metrics for prometheus to consume:
 - ffperf_runner_unexpected_events_total
 - ffperf_runner_sent_mints_total
 - ffperf_runner_sent_mint_errors_total
+- ffperf_running_mint_token_balance (gauge)
 - ffperf_runner_deliquent_msgs_total
 - ffperf_runner_perf_test_duration_seconds
 
@@ -128,6 +129,8 @@ There are various options for creating your own customized tests. A full list of
   - `supportsData` defaults to `true` since the sample token contract used by FireFly supports minting tokens with data. When set to `true` the message included in the mint transaction will include the ID of the worker routine and used to correlate received confirmation events.
   - `supportsURI` defaults to `true` for nonfungible tokens. This attribute is ignored for fungible token tests. If set to `true` the ID of a worker routine will be set in the URI and used to correlate received confirmation events.
   - If neither attribute is set to true any received confirmation events cannot be correlated with mint transactions. In this case the test behaves as if `skipMintConfirmations` is set to `true`.
+- Waiting at the end of the test for the minted token balance of the `mintRecipient` address to equal the expected value. Since a test might be run several times with the same address the test gets the balance at the beginning of the test, and then again at the end. The difference is expected to equal the value of `maxActions`. To enable this check set the `maxTokenBalanceWait` token option the length of time to wait for the balance to be reached. If `maxTokenBalanceWait` is not set the test will not check balances.
+- Having a worker loop submit more than 1 action per loop by setting `actionsPerLoop` for the test. This can be helpful when you want to scale the number of actions done in parallel without having to scale the number of workers. The default value is `1` for this attribute. If setting to a value > `1` it is recommended to have `skipMintConfirmations` to set `false`.
 
 ## Distributed Deployment
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -246,6 +246,12 @@ func setDefaults(runnerConfig *conf.RunnerConfig) {
 	} else if runnerConfig.EndRate == 0 {
 		runnerConfig.EndRate = runnerConfig.StartRate
 	}
+
+	for i, _ := range runnerConfig.Tests {
+		if runnerConfig.Tests[i].ActionsPerLoop <= 0 {
+			runnerConfig.Tests[i].ActionsPerLoop = 1
+		}
+	}
 }
 
 func validateConfig(cfg *conf.RunnerConfig, instance *conf.InstanceConfig, globalConfig *conf.PerformanceTestConfig) error {

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -47,7 +47,7 @@ type RunnerConfig struct {
 	MaxActions                int64
 	StartRate                 int64
 	EndRate                   int64
-	RateRampUpTime            int64
+	RateRampUpTime            time.Duration
 	SkipMintConfirmations     bool
 }
 
@@ -77,7 +77,7 @@ type InstanceConfig struct {
 	MaxActions                int64            `json:"maxActions,omitempty" yaml:"maxActions,omitempty"`
 	StartRate                 int64            `json:"startRate,omitempty" yaml:"startRate,omitempty"`
 	EndRate                   int64            `json:"endRate,omitempty" yaml:"endRate,omitempty"`
-	RateRampUpTime            int64            `json:"rateRampUpTime,omitempty" yaml:"rateRampUpTime,omitempty"`
+	RateRampUpTime            time.Duration    `json:"rateRampUpTime,omitempty" yaml:"rateRampUpTime,omitempty"`
 	SkipMintConfirmations     bool             `json:"skipMintConfirmations,omitempty" yaml:"skipMintConfirmations,omitempty"`
 	DelinquentAction          string           `json:"delinquentAction,omitempty" yaml:"delinquentAction,omitempty"`
 	PerWorkerSigningKeyPrefix string           `json:"perWorkerSigningKeyPrefix,omitempty" yaml:"perWorkerSigningKeyPrefix,omitempty"`
@@ -100,13 +100,14 @@ type MessageOptions struct {
 }
 
 type TokenOptions struct {
-	TokenType              string      `json:"tokenType" yaml:"tokenType"`
-	TokenPoolConnectorName string      `json:"poolConnectorName" yaml:"poolConnectorName"`
-	SupportsData           *bool       `json:"supportsData" yaml:"supportsData"` // Needs to be a pointer to allow defaulting to 'true'
-	SupportsURI            bool        `json:"supportsURI" yaml:"supportsURI"`
-	ExistingPoolName       string      `json:"existingPoolName" yaml:"existingPoolName"`
-	RecipientAddress       string      `json:"mintRecipient,omitempty" yaml:"mintRecipient,omitempty"`
-	Config                 TokenConfig `json:"config" yaml:"config"`
+	TokenType              string        `json:"tokenType" yaml:"tokenType"`
+	TokenPoolConnectorName string        `json:"poolConnectorName" yaml:"poolConnectorName"`
+	SupportsData           *bool         `json:"supportsData" yaml:"supportsData"` // Needs to be a pointer to allow defaulting to 'true'
+	SupportsURI            bool          `json:"supportsURI" yaml:"supportsURI"`
+	ExistingPoolName       string        `json:"existingPoolName" yaml:"existingPoolName"`
+	RecipientAddress       string        `json:"mintRecipient,omitempty" yaml:"mintRecipient,omitempty"`
+	Config                 TokenConfig   `json:"config" yaml:"config"`
+	MaxTokenBalanceWait    time.Duration `json:"maxTokenBalanceWait,omitempty" yaml:"maxTokenBalanceWait,omitempty"`
 }
 
 type TokenConfig struct {

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -84,8 +84,9 @@ type InstanceConfig struct {
 }
 
 type TestCaseConfig struct {
-	Name    fftypes.FFEnum `json:"name" yaml:"name"`
-	Workers int            `json:"workers" yaml:"workers"`
+	Name           fftypes.FFEnum `json:"name" yaml:"name"`
+	Workers        int            `json:"workers" yaml:"workers"`
+	ActionsPerLoop int            `json:"actionsPerLoop" yaml:"actionsPerLoop"`
 }
 
 type NodeConfig struct {

--- a/internal/perf/blob_broadcast_msg.go
+++ b/internal/perf/blob_broadcast_msg.go
@@ -14,11 +14,12 @@ type blobBroadcast struct {
 	testBase
 }
 
-func newBlobBroadcastTestWorker(pr *perfRunner, workerID int) TestCase {
+func newBlobBroadcastTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
 	return &blobBroadcast{
 		testBase: testBase{
-			pr:       pr,
-			workerID: workerID,
+			pr:             pr,
+			workerID:       workerID,
+			actionsPerLoop: actionsPerLoop,
 		},
 	}
 }

--- a/internal/perf/blob_private_msg.go
+++ b/internal/perf/blob_private_msg.go
@@ -14,11 +14,12 @@ type blobPrivate struct {
 	testBase
 }
 
-func newBlobPrivateTestWorker(pr *perfRunner, workerID int) TestCase {
+func newBlobPrivateTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
 	return &blobPrivate{
 		testBase: testBase{
-			pr:       pr,
-			workerID: workerID,
+			pr:             pr,
+			workerID:       workerID,
+			actionsPerLoop: actionsPerLoop,
 		},
 	}
 }

--- a/internal/perf/broadcast_msg.go
+++ b/internal/perf/broadcast_msg.go
@@ -13,11 +13,12 @@ type broadcast struct {
 	testBase
 }
 
-func newBroadcastTestWorker(pr *perfRunner, workerID int) TestCase {
+func newBroadcastTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
 	return &broadcast{
 		testBase: testBase{
-			pr:       pr,
-			workerID: workerID,
+			pr:             pr,
+			workerID:       workerID,
+			actionsPerLoop: actionsPerLoop,
 		},
 	}
 }

--- a/internal/perf/custom_ethereum_contract.go
+++ b/internal/perf/custom_ethereum_contract.go
@@ -29,11 +29,12 @@ type customEthereum struct {
 	testBase
 }
 
-func newCustomEthereumTestWorker(pr *perfRunner, workerID int) TestCase {
+func newCustomEthereumTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
 	return &customEthereum{
 		testBase: testBase{
-			pr:       pr,
-			workerID: workerID,
+			pr:             pr,
+			workerID:       workerID,
+			actionsPerLoop: actionsPerLoop,
 		},
 	}
 }

--- a/internal/perf/custom_fabric_contract.go
+++ b/internal/perf/custom_fabric_contract.go
@@ -29,11 +29,12 @@ type customFabric struct {
 	testBase
 }
 
-func newCustomFabricTestWorker(pr *perfRunner, workerID int) TestCase {
+func newCustomFabricTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
 	return &customFabric{
 		testBase: testBase{
-			pr:       pr,
-			workerID: workerID,
+			pr:             pr,
+			workerID:       workerID,
+			actionsPerLoop: actionsPerLoop,
 		},
 	}
 }

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -705,10 +705,6 @@ func (pr *perfRunner) runLoop(tc TestCase) error {
 			}
 			log.Infof("%d <-- %s Finished (loop=%d)", workerID, testName, loop)
 
-			// for _, trackingID := range trackingIDs {
-			// 	pr.markTestComplete(trackingID)
-			// }
-
 			if histErr == nil {
 				hist.Observe(time.Since(startTime).Seconds())
 			}

--- a/internal/perf/private_msg.go
+++ b/internal/perf/private_msg.go
@@ -13,11 +13,12 @@ type private struct {
 	testBase
 }
 
-func newPrivateTestWorker(pr *perfRunner, workerID int) TestCase {
+func newPrivateTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
 	return &private{
 		testBase: testBase{
-			pr:       pr,
-			workerID: workerID,
+			pr:             pr,
+			workerID:       workerID,
+			actionsPerLoop: actionsPerLoop,
 		},
 	}
 }

--- a/internal/perf/test_base.go
+++ b/internal/perf/test_base.go
@@ -13,12 +13,17 @@ import (
 )
 
 type testBase struct {
-	pr       *perfRunner
-	workerID int
+	pr             *perfRunner
+	workerID       int
+	actionsPerLoop int
 }
 
 func (t *testBase) WorkerID() int {
 	return t.workerID
+}
+
+func (t *testBase) ActionsPerLoop() int {
+	return t.actionsPerLoop
 }
 
 func resStatus(res *resty.Response) int {

--- a/internal/perf/token_mint.go
+++ b/internal/perf/token_mint.go
@@ -29,11 +29,12 @@ type tokenMint struct {
 	testBase
 }
 
-func newTokenMintTestWorker(pr *perfRunner, workerID int) TestCase {
+func newTokenMintTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
 	return &tokenMint{
 		testBase: testBase{
-			pr:       pr,
-			workerID: workerID,
+			pr:             pr,
+			workerID:       workerID,
+			actionsPerLoop: actionsPerLoop,
 		},
 	}
 }


### PR DESCRIPTION
This change adds:
 - An optional check of the recipient token balance at the end of the test (plus a metric to track it over time)
 - Multiple actions per worker loop (so you can scale the number of parallel requests separately to scaling the workers)