### PR TITLE
Manual endpoints skipped config from instances

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -152,7 +152,6 @@ func generateRunnerConfigFromInstance(instance *conf.InstanceConfig, perfConfig 
 		// Use manual endpoint configuration instead of getting it from a FireFly stack
 		log.Infof("Running test against manual endpoint \"%s\"\n", perfConfig.Nodes[instance.ManualNodeIndex].APIEndpoint)
 
-		runnerConfig.TokenOptions = instance.TokenOptions
 		runnerConfig.NodeURLs = make([]string, 0)
 		runnerConfig.NodeURLs = append(runnerConfig.NodeURLs, perfConfig.Nodes[instance.ManualNodeIndex].APIEndpoint)
 		runnerConfig.SenderURL = runnerConfig.NodeURLs[0]
@@ -191,16 +190,17 @@ func generateRunnerConfigFromInstance(instance *conf.InstanceConfig, perfConfig 
 			runnerConfig.NodeURLs[i] = fmt.Sprintf("%s://%s:%v", scheme, member.FireflyHostname, member.ExposedFireflyPort)
 		}
 
-		runnerConfig.MessageOptions = instance.MessageOptions
-		runnerConfig.TokenOptions = instance.TokenOptions
-		runnerConfig.ContractOptions = instance.ContractOptions
-
 		runnerConfig.SenderURL = runnerConfig.NodeURLs[instance.Sender]
 		if instance.Recipient != nil {
 			runnerConfig.RecipientOrg = fmt.Sprintf("did:firefly:org/%s", stack.Members[*instance.Recipient].OrgName)
 			runnerConfig.RecipientAddress = stack.Members[*instance.Recipient].Address
 		}
 	}
+
+	runnerConfig.TokenOptions = instance.TokenOptions
+	runnerConfig.MessageOptions = instance.MessageOptions
+	runnerConfig.TokenOptions = instance.TokenOptions
+	runnerConfig.ContractOptions = instance.ContractOptions
 
 	// Common configuration regardless of running with manually defined nodes or a local stack
 	runnerConfig.SkipMintConfirmations = instance.SkipMintConfirmations

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -256,6 +256,8 @@ func (pr *perfRunner) Start() (err error) {
 		}
 	}
 
+	log.Infof("Running test:\n%+v", pr.cfg)
+
 	for _, nodeURL := range pr.nodeURLs {
 
 		if containsTargetTest(pr.cfg.Tests, conf.PerfTestTokenMint) {

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -951,20 +951,22 @@ func (pr *perfRunner) createEthereumContractListener(nodeURL string) (string, er
 		"topic": "%s"
 	}`, pr.cfg.ContractOptions.Address, fftypes.NewUUID())
 
+	var errResponse fftypes.RESTError
+	var responseBody map[string]interface{}
 	res, err := pr.client.R().
 		SetHeaders(map[string]string{
 			"Accept":       "application/json",
 			"Content-Type": "application/json",
 		}).
 		SetBody(subPayload).
+		SetResult(&responseBody).
+		SetError(&errResponse).
 		Post(fmt.Sprintf("%s/%sapi/v1/namespaces/%s/contracts/listeners", nodeURL, pr.cfg.APIPrefix, pr.cfg.FFNamespace))
 	if err != nil {
 		return "", err
 	}
-	var responseBody map[string]interface{}
-	err = json.Unmarshal(res.Body(), &responseBody)
-	if err != nil {
-		return "", err
+	if res.IsError() {
+		return "", fmt.Errorf("Failed: %s", errResponse)
 	}
 	id := responseBody["id"].(string)
 	log.Infof("Created contract listener on %s: %s", nodeURL, id)


### PR DESCRIPTION
Found that the test runner for "manual endpoint" configurations, did not pick up mandatory config from the `instances` array.

The error was as follows, so I had to add some debug first (to get it to report the error from FireFly, rather than assuming a HTTP OK response):

```
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/hyperledger/firefly-perf-cli/internal/perf.(*perfRunner).createEthereumContractListener(0xc0000bfc00, {0xc000026240, 0x37})
	/home/ubuntu/test-dtcc-kap/firefly-perf-cli/internal/perf/perf.go:969 +0x690
github.com/hyperledger/firefly-perf-cli/internal/perf.(*perfRunner).Start(0xc0000bfc00)
	/home/ubuntu/test-dtcc-kap/firefly-perf-cli/internal/perf/perf.go:284 +0x347
github.com/hyperledger/firefly-perf-cli/cmd.glob..func2(0x1021520, {0xad09fb, 0x4, 0x4})
	/home/ubuntu/test-dtcc-kap/firefly-perf-cli/cmd/run.go:89 +0x93
github.com/spf13/cobra.(*Command).execute(0x1021520, {0xc00006c140, 0x4, 0x4})
	/home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x842
github.com/spf13/cobra.(*Command).ExecuteC(0x1021240)
	/home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3cd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/hyperledger/firefly-perf-cli/cmd.Execute()
	/home/ubuntu/test-dtcc-kap/firefly-perf-cli/cmd/root.go:64 +0x25
main.main()
	/home/ubuntu/test-dtcc-kap/firefly-perf-cli/ffperf/main.go:26 +0x19
```