### PR TITLE
Idempotency key and better retries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/hyperledger/firefly v1.2.0
-	github.com/hyperledger/firefly-common v1.2.13
+	github.com/hyperledger/firefly-common v1.2.15
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,10 @@ github.com/hyperledger/firefly v1.2.0 h1:No82vzsur3TODU0giIECDcMnWQ/8BRGoYo7QK/a
 github.com/hyperledger/firefly v1.2.0/go.mod h1:tmpTfSjX/NIa7xHTtTb36S48X9+3nNutY7ZxLt3lgCU=
 github.com/hyperledger/firefly-common v1.2.13 h1:4pGL8LusXoijeoxM9J36fzBq4jvZpZbGjpQqgempXMk=
 github.com/hyperledger/firefly-common v1.2.13/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
+github.com/hyperledger/firefly-common v1.2.14 h1:HON9GJZXvrL0l2AG5DWHSGiBh05hElgFS5lm1OPR83M=
+github.com/hyperledger/firefly-common v1.2.14/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
+github.com/hyperledger/firefly-common v1.2.15 h1:WdNB65IJvIyiOhVW3nxB3sQKqtJbdJ7ie0PJIM11CSU=
+github.com/hyperledger/firefly-common v1.2.15/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -17,6 +17,7 @@
 package conf
 
 import (
+	"crypto/tls"
 	"net/url"
 	"time"
 
@@ -132,6 +133,8 @@ type FireFlyWsConfig struct {
 	HeartbeatInterval      time.Duration `mapstructure:"heartbeatInterval" json:"heartbeatInterval" yaml:"heartbeatInterval"`
 	AuthUsername           string        `mapstructure:"authUsername" json:"authUsername" yaml:"authUsername"`
 	AuthPassword           string        `mapstructure:"authPassword" json:"authPassword" yaml:"authPassword"`
+	DisableTLSVerification bool          `mapstructure:"disableTLSVerification" json:"disableTLSVerification" yaml:"disableTLSVerification"`
+	ConnectionTimeout      time.Duration `mapstructure:"connectionTimeout" json:"connectionTimeout" yaml:"connectionTimeout"`
 }
 
 func GenerateWSConfig(nodeURL string, conf *FireFlyWsConfig) *wsclient.WSConfig {
@@ -148,6 +151,10 @@ func GenerateWSConfig(nodeURL string, conf *FireFlyWsConfig) *wsclient.WSConfig 
 		HeartbeatInterval:      conf.HeartbeatInterval,
 		AuthUsername:           conf.AuthUsername,
 		AuthPassword:           conf.AuthPassword,
+		ConnectionTimeout:      conf.ConnectionTimeout,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: conf.DisableTLSVerification,
+		},
 	}
 }
 

--- a/internal/perf/custom_ethereum_contract.go
+++ b/internal/perf/custom_ethereum_contract.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/hyperledger/firefly-perf-cli/internal/conf"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 )
@@ -86,7 +87,11 @@ func (tc *customEthereum) RunOnce() (string, error) {
 		SetError(&resError).
 		Post(fmt.Sprintf("%s/%sapi/v1/namespaces/%s/contracts/invoke", tc.pr.client.BaseURL, tc.pr.cfg.APIPrefix, tc.pr.cfg.FFNamespace))
 	if err != nil || res.IsError() {
-		return "", fmt.Errorf("Error invoking contract [%d]: %s (%+v)", resStatus(res), err, &resError)
+		if res.StatusCode() == 409 {
+			log.Warnf("Request already received by FireFly: %+v", &resError)
+		} else {
+			return "", fmt.Errorf("Error invoking contract [%d]: %s (%+v)", resStatus(res), err, &resError)
+		}
 	}
 	tc.iteration++
 	return strconv.Itoa(tc.workerID), nil

--- a/internal/perf/custom_ethereum_contract.go
+++ b/internal/perf/custom_ethereum_contract.go
@@ -27,6 +27,7 @@ import (
 
 type customEthereum struct {
 	testBase
+	iteration int
 }
 
 func newCustomEthereumTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
@@ -48,6 +49,7 @@ func (tc *customEthereum) IDType() TrackingIDType {
 }
 
 func (tc *customEthereum) RunOnce() (string, error) {
+	idempotencyKey := tc.pr.getIdempotencyKey(tc.workerID, tc.iteration)
 	payload := fmt.Sprintf(`{
 		"location": {
 			"address": "%s"
@@ -69,8 +71,9 @@ func (tc *customEthereum) RunOnce() (string, error) {
 		},
 		"input": {
 			"newValue": %v
-		}
-	}`, tc.pr.cfg.ContractOptions.Address, tc.workerID)
+		},
+		"idempotencyKey": "%s"
+	}`, tc.pr.cfg.ContractOptions.Address, tc.workerID, idempotencyKey)
 	var resContractCall map[string]interface{}
 	var resError fftypes.RESTError
 	res, err := tc.pr.client.R().
@@ -85,5 +88,6 @@ func (tc *customEthereum) RunOnce() (string, error) {
 	if err != nil || res.IsError() {
 		return "", fmt.Errorf("Error invoking contract [%d]: %s (%+v)", resStatus(res), err, &resError)
 	}
+	tc.iteration++
 	return strconv.Itoa(tc.workerID), nil
 }


### PR DESCRIPTION
This PR adds support for a few new features including:

- Custom Ethereum contract transactions now use an idempotency key. This should be easy to extend to other test cases if desired.  
- Automatic retries for failed HTTP requests (except 409)
- The option to disable TLS verification on the websocket client (useful for local testing)
- A configurable connection timeout on the websocket client. The previous default timeout was 45 seconds, which could be longer than the `maxTimePerAction`. To configure the new options you can set them in your `instances.yml` file

```
wsConfig:
  connectionTimeout: 5s
  disableTLSVerification: true
```

> NOTE: In order for the perf-cli to successfully reconnect and resume testing, the websocket `connectionTimeout` needs to be less than your configured `maxTimePerAction`, otherwise the tool will consider the test a failure before it has a chance to reconnect and begin receiving events again.