### PR TITLE
Add invokeOptions

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -145,6 +145,7 @@ func generateRunnerConfigFromInstance(instance *conf.InstanceConfig, perfConfig 
 	}
 
 	runnerConfig.WebSocket = perfConfig.WSConfig
+	runnerConfig.InvokeOptions = instance.InvokeOptions
 
 	if len(perfConfig.Nodes) > 0 {
 		// Use node configuration defined in the ffperf config file

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -29,6 +29,7 @@ type RunnerConfig struct {
 	Tests                     []TestCaseConfig
 	Length                    time.Duration
 	MessageOptions            MessageOptions
+	InvokeOptions             interface{}
 	RecipientOrg              string
 	RecipientAddress          string
 	SigningKey                string
@@ -66,6 +67,7 @@ type InstanceConfig struct {
 	Tests                     []TestCaseConfig `yaml:"tests" json:"tests"`
 	Length                    time.Duration    `yaml:"length" json:"length"`
 	MessageOptions            MessageOptions   `json:"messageOptions,omitempty" yaml:"messageOptions,omitempty"`
+	InvokeOptions             interface{}      `json:"invokeOptions,omitempty" yaml:"invokeOptions,omitempty"`
 	Sender                    int              `json:"sender" yaml:"sender"`
 	ManualNodeIndex           int              `json:"manualNodeIndex" yaml:"manualNodeIndex"`
 	Recipient                 *int             `json:"recipient,omitempty" yaml:"recipient,omitempty"`

--- a/internal/perf/custom_ethereum_contract.go
+++ b/internal/perf/custom_ethereum_contract.go
@@ -17,6 +17,7 @@
 package perf
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -51,6 +52,13 @@ func (tc *customEthereum) IDType() TrackingIDType {
 
 func (tc *customEthereum) RunOnce() (string, error) {
 	idempotencyKey := tc.pr.getIdempotencyKey(tc.workerID, tc.iteration)
+	invokeOptionsJSON := ""
+	if tc.pr.cfg.InvokeOptions != nil {
+		b, err := json.Marshal(tc.pr.cfg.InvokeOptions)
+		if err == nil {
+			invokeOptionsJSON = fmt.Sprintf(",\n		 \"options\": %s", b)
+		}
+	}
 	payload := fmt.Sprintf(`{
 		"location": {
 			"address": "%s"
@@ -73,8 +81,8 @@ func (tc *customEthereum) RunOnce() (string, error) {
 		"input": {
 			"newValue": %v
 		},
-		"idempotencyKey": "%s"
-	}`, tc.pr.cfg.ContractOptions.Address, tc.workerID, idempotencyKey)
+		"idempotencyKey": "%s"%s
+	}`, tc.pr.cfg.ContractOptions.Address, tc.workerID, idempotencyKey, invokeOptionsJSON)
 	var resContractCall map[string]interface{}
 	var resError fftypes.RESTError
 	res, err := tc.pr.client.R().


### PR DESCRIPTION
Allow custom options like `gas` to be specified:

```yaml
instances:
  - name: my-instance
    manualNodeIndex: 0
    tests: [{ "name": "custom_ethereum_contract", "workers": 1, "actionsPerLoop": 1 }]
    ...
    invokeOptions:
      gas: "100000"