### PR TITLE
Fix retries. Add log level customization. Turn on debug profiler

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -204,6 +204,7 @@ func generateRunnerConfigFromInstance(instance *conf.InstanceConfig, perfConfig 
 	runnerConfig.ContractOptions = instance.ContractOptions
 
 	// Common configuration regardless of running with manually defined nodes or a local stack
+	runnerConfig.LogLevel = perfConfig.LogLevel
 	runnerConfig.SkipMintConfirmations = instance.SkipMintConfirmations
 	runnerConfig.Length = instance.Length
 	runnerConfig.Daemon = perfConfig.Daemon

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/hyperledger/firefly v1.2.0
-	github.com/hyperledger/firefly-common v1.2.15
+	github.com/hyperledger/firefly-common v1.2.16
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/hyperledger/firefly-common v1.2.14 h1:HON9GJZXvrL0l2AG5DWHSGiBh05hElg
 github.com/hyperledger/firefly-common v1.2.14/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
 github.com/hyperledger/firefly-common v1.2.15 h1:WdNB65IJvIyiOhVW3nxB3sQKqtJbdJ7ie0PJIM11CSU=
 github.com/hyperledger/firefly-common v1.2.15/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
+github.com/hyperledger/firefly-common v1.2.16 h1:cVSaxKycOb+/oT2wExbrzxr68aVKQObeBOLaiJ0mTLg=
+github.com/hyperledger/firefly-common v1.2.16/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -26,6 +26,7 @@ import (
 )
 
 type RunnerConfig struct {
+	LogLevel                  string
 	Tests                     []TestCaseConfig
 	Length                    time.Duration
 	MessageOptions            MessageOptions
@@ -54,6 +55,7 @@ type RunnerConfig struct {
 }
 
 type PerformanceTestConfig struct {
+	LogLevel      string           `yaml:"logLevel" json:"logLevel"`
 	StackJSONPath string           `json:"stackJSONPath" yaml:"stackJSONPath"`
 	Instances     []InstanceConfig `json:"instances" yaml:"instances"`
 	WSConfig      FireFlyWsConfig  `json:"wsConfig,omitempty" yaml:"wsConfig,omitempty"`

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -235,7 +235,7 @@ func New(config *conf.RunnerConfig) PerfRunner {
 	for i, nodeURL := range config.NodeURLs {
 		// Create websocket client
 		wsConfig := conf.GenerateWSConfig(nodeURL, &config.WebSocket)
-		wsconn, err := wsclient.New(pr.ctx, wsConfig, nil, pr.startSubscriptions)
+		wsconn, err := wsclient.New(context.Background(), wsConfig, nil, pr.startSubscriptions)
 		if err != nil {
 			log.Errorf("Could not create websocket connection: %s", err)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,13 +19,15 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
 )
 
 type HttpServer struct {
@@ -46,6 +48,10 @@ func NewHttpServer() *HttpServer {
 
 	hs.mux.HandleFunc("/status", statusHandler)
 	hs.mux.Handle("/metrics", promhttp.Handler())
+
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
 
 	hs.shutdown = make(chan struct{})
 


### PR DESCRIPTION
This PR fixes a bug in our resty retry hook. This allows the test to continue retrying requests in the event of an error response. Previously this was causing some worker routines to end early, causing an apparent drop in throughput.

This PR also adds some extra debugging capabilities, and pulls in a new version of firefly-common which doesn't try to automatically reconnect when the ws client context is canceled.