### PR TITLE
Adding latency metrics to the report and fixing actionsPerLoop

### DIFF
--- a/internal/perf/blob_broadcast_msg.go
+++ b/internal/perf/blob_broadcast_msg.go
@@ -33,7 +33,7 @@ func (tc *blobBroadcast) IDType() TrackingIDType {
 	return TrackingIDTypeMessageID
 }
 
-func (tc *blobBroadcast) RunOnce() (string, error) {
+func (tc *blobBroadcast) RunOnce(iterationCount int) (string, error) {
 
 	blob, hash := tc.generateBlob(big.NewInt(1024))
 	dataID, err := tc.uploadBlob(blob, hash, tc.pr.client.BaseURL)

--- a/internal/perf/blob_private_msg.go
+++ b/internal/perf/blob_private_msg.go
@@ -33,7 +33,7 @@ func (tc *blobPrivate) IDType() TrackingIDType {
 	return TrackingIDTypeMessageID
 }
 
-func (tc *blobPrivate) RunOnce() (string, error) {
+func (tc *blobPrivate) RunOnce(iterationCount int) (string, error) {
 
 	blob, hash := tc.generateBlob(big.NewInt(1024))
 	dataID, err := tc.uploadBlob(blob, hash, tc.pr.client.BaseURL)

--- a/internal/perf/broadcast_msg.go
+++ b/internal/perf/broadcast_msg.go
@@ -32,7 +32,7 @@ func (tc *broadcast) IDType() TrackingIDType {
 	return TrackingIDTypeMessageID
 }
 
-func (tc *broadcast) RunOnce() (string, error) {
+func (tc *broadcast) RunOnce(iterationCount int) (string, error) {
 
 	payload := fmt.Sprintf(`{
 		"data":[

--- a/internal/perf/custom_ethereum_contract.go
+++ b/internal/perf/custom_ethereum_contract.go
@@ -30,7 +30,6 @@ import (
 
 type customEthereum struct {
 	testBase
-	iteration int
 }
 
 func newCustomEthereumTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
@@ -51,8 +50,8 @@ func (tc *customEthereum) IDType() TrackingIDType {
 	return TrackingIDTypeWorkerNumber
 }
 
-func (tc *customEthereum) RunOnce() (string, error) {
-	idempotencyKey := tc.pr.getIdempotencyKey(tc.workerID, tc.iteration)
+func (tc *customEthereum) RunOnce(iterationCount int) (string, error) {
+	idempotencyKey := tc.pr.getIdempotencyKey(tc.workerID, iterationCount)
 	invokeOptionsJSON := ""
 	if tc.pr.cfg.InvokeOptions != nil {
 		b, err := json.Marshal(tc.pr.cfg.InvokeOptions)
@@ -106,6 +105,5 @@ func (tc *customEthereum) RunOnce() (string, error) {
 			return "", fmt.Errorf("Error invoking contract [%d]: %s (%+v)", resStatus(res), err, &resError)
 		}
 	}
-	tc.iteration++
 	return strconv.Itoa(tc.workerID), nil
 }

--- a/internal/perf/custom_fabric_contract.go
+++ b/internal/perf/custom_fabric_contract.go
@@ -29,7 +29,6 @@ import (
 
 type customFabric struct {
 	testBase
-	iteration int
 }
 
 func newCustomFabricTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
@@ -50,8 +49,8 @@ func (tc *customFabric) IDType() TrackingIDType {
 	return TrackingIDTypeWorkerNumber
 }
 
-func (tc *customFabric) RunOnce() (string, error) {
-	idempotencyKey := tc.pr.getIdempotencyKey(tc.workerID, tc.iteration)
+func (tc *customFabric) RunOnce(iterationCount int) (string, error) {
+	idempotencyKey := tc.pr.getIdempotencyKey(tc.workerID, iterationCount)
 	invokeOptionsJSON := ""
 	if tc.pr.cfg.InvokeOptions != nil {
 		b, err := json.Marshal(tc.pr.cfg.InvokeOptions)
@@ -143,6 +142,5 @@ func (tc *customFabric) RunOnce() (string, error) {
 	if err != nil || res.IsError() {
 		return "", fmt.Errorf("Error invoking contract [%d]: %s (%+v)", resStatus(res), err, &resError)
 	}
-	tc.iteration++
 	return strconv.Itoa(tc.workerID), nil
 }

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -760,6 +760,7 @@ func (pr *perfRunner) runLoop(tc TestCase) error {
 				}
 				// if we've reached the expected amount of metadata calls then stop
 				if resultCount == tc.ActionsPerLoop() {
+					log.Infof("%d --> %s All actions sent %d", workerID, testName, resultCount)
 					break
 				}
 			}

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -736,7 +736,7 @@ func (pr *perfRunner) runLoop(tc TestCase) error {
 				}
 
 				trackingID, err := tc.RunOnce()
-
+				log.Infof("%d --> %s action %d sent after %f seconds", workerID, testName, actionsCompleted, time.Since(startTime).Seconds())
 				actionResponses <- &ActionResponse{
 					trackingID: trackingID,
 					err:        err,

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -774,10 +774,13 @@ func (pr *perfRunner) runLoop(tc TestCase) error {
 					pr.stopTrackingRequest(nextTrackingID)
 				}
 			}
-			log.Infof("%d <-- %s Finished (loop=%d)", workerID, testName, loop)
+			secondsPerLoop := time.Since(startTime).Seconds()
+			log.Infof("%d <-- %s Finished (loop=%d) after %f seconds", workerID, testName, loop, secondsPerLoop)
 
 			if histErr == nil {
-				hist.Observe(time.Since(startTime).Seconds())
+				log.Infof("%d <-- %s Emmiting (loop=%d) after %f seconds", workerID, testName, loop, secondsPerLoop)
+
+				hist.Observe(secondsPerLoop)
 			}
 			loop++
 

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -734,13 +734,15 @@ func (pr *perfRunner) runLoop(tc TestCase) error {
 				if pr.allActionsComplete() {
 					break
 				}
-
-				trackingID, err := tc.RunOnce()
-				log.Infof("%d --> %s action %d sent after %f seconds", workerID, testName, actionsCompleted, time.Since(startTime).Seconds())
-				actionResponses <- &ActionResponse{
-					trackingID: trackingID,
-					err:        err,
-				}
+				actionCount := actionsCompleted
+				go func() {
+					trackingID, err := tc.RunOnce()
+					log.Infof("%d --> %s action %d sent after %f seconds", workerID, testName, actionCount, time.Since(startTime).Seconds())
+					actionResponses <- &ActionResponse{
+						trackingID: trackingID,
+						err:        err,
+					}
+				}()
 			}
 			resultCount := 0
 			for {

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -141,7 +141,7 @@ const (
 
 type TestCase interface {
 	WorkerID() int
-	RunOnce() (trackingID string, err error)
+	RunOnce(iterationCount int) (trackingID string, err error)
 	IDType() TrackingIDType
 	Name() string
 	ActionsPerLoop() int
@@ -736,7 +736,7 @@ func (pr *perfRunner) runLoop(tc TestCase) error {
 				}
 				actionCount := actionsCompleted
 				go func() {
-					trackingID, err := tc.RunOnce()
+					trackingID, err := tc.RunOnce(actionCount)
 					log.Infof("%d --> %s action %d sent after %f seconds", workerID, testName, actionCount, time.Since(startTime).Seconds())
 					actionResponses <- &ActionResponse{
 						trackingID: trackingID,

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -1296,7 +1296,7 @@ func (pr *perfRunner) getIdempotencyKey(workerId int, iteration int) string {
 	workerIdStr := fmt.Sprintf("%05d", workerId)
 	// Left pad iteration ID to 9 digits (supporting up to 999,999,999 iterations)
 	iterationIdStr := fmt.Sprintf("%09d", iteration)
-	return fmt.Sprintf("%v-%s-%s", pr.startTime, workerIdStr, iterationIdStr)
+	return fmt.Sprintf("%v-%s-%s-%s", pr.startTime, workerIdStr, iterationIdStr, fftypes.NewUUID())
 }
 
 func (pr *perfRunner) calculateCurrentTps(logValue bool) float64 {

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -760,7 +760,7 @@ func (pr *perfRunner) runLoop(tc TestCase) error {
 				}
 				// if we've reached the expected amount of metadata calls then stop
 				if resultCount == tc.ActionsPerLoop() {
-					log.Infof("%d --> %s All actions sent %d", workerID, testName, resultCount)
+					log.Infof("%d --> %s All actions sent %d after %f seconds", workerID, testName, resultCount, time.Since(startTime).Seconds())
 					break
 				}
 			}

--- a/internal/perf/private_msg.go
+++ b/internal/perf/private_msg.go
@@ -32,7 +32,7 @@ func (tc *private) IDType() TrackingIDType {
 	return TrackingIDTypeMessageID
 }
 
-func (tc *private) RunOnce() (string, error) {
+func (tc *private) RunOnce(iterationCount int) (string, error) {
 
 	payload := fmt.Sprintf(`{
 		"data": [

--- a/internal/perf/token_mint.go
+++ b/internal/perf/token_mint.go
@@ -60,7 +60,7 @@ func (tc *tokenMint) GetSigningKey() string {
 	return ""
 }
 
-func (tc *tokenMint) RunOnce() (string, error) {
+func (tc *tokenMint) RunOnce(iterationCount int) (string, error) {
 	var payload string
 	mintAmount := 10
 	if tc.pr.cfg.TokenOptions.TokenType == core.TokenTypeNonFungible.String() {


### PR DESCRIPTION
- [ ] Actions in a loop are not emitted in parallel. Based on description: `This can be helpful when you want to scale the number of actions done in parallel without having to scale the number of workers.` I believe it's intended that actions should be triggered in parallel.
- [ ] Add latency metrics 
- [ ] Report latency metrics in the final report