### PR TITLE
adding support for erc20 test case

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -92,9 +92,6 @@ type InstanceConfig struct {
 	SubscriptionCoreOptions   *core.SubscriptionCoreOptions `json:"subscriptionOptions,omitempty" yaml:"subscriptionOptions,omitempty"`
 }
 
-type SubscriptionOptions struct {
-}
-
 type TestCaseConfig struct {
 	Name           fftypes.FFEnum `json:"name" yaml:"name"`
 	Workers        int            `json:"workers" yaml:"workers"`

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -189,6 +189,8 @@ var (
 	PerfTestTokenMint fftypes.FFEnum = "token_mint"
 	// PerfTestCustomEthereumContract invokes a custom smart contract and checks events emitted by it
 	PerfTestCustomEthereumContract fftypes.FFEnum = "custom_ethereum_contract"
+	// PerfTestCustomEthereumContract invokes an erc20 transfer and checks events emitted by it
+	PerfTestERC20TransferContract fftypes.FFEnum = "erc20_transfer"
 	// PerfTestCustomFabricContract invokes a custom smart contract and checks events emitted by it
 	PerfTestCustomFabricContract fftypes.FFEnum = "custom_fabric_contract"
 	// PerfTestBlobBroadcast broadcasts a blob

--- a/internal/perf/erc20transfer.go
+++ b/internal/perf/erc20transfer.go
@@ -1,0 +1,132 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perf
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/hyperledger/firefly-perf-cli/internal/conf"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
+)
+
+type erc20Transfer struct {
+	testBase
+}
+
+func newERC20TransferTestWorker(pr *perfRunner, workerID int, actionsPerLoop int) TestCase {
+	return &erc20Transfer{
+		testBase: testBase{
+			pr:             pr,
+			workerID:       workerID,
+			actionsPerLoop: actionsPerLoop,
+		},
+	}
+}
+
+func (tc *erc20Transfer) Name() string {
+	return conf.PerfTestERC20TransferContract.String()
+}
+
+func (tc *erc20Transfer) IDType() TrackingIDType {
+	return TrackingIDTypeWorkerNumber
+}
+
+func (tc *erc20Transfer) RunOnce(iterationCount int) (string, error) {
+	idempotencyKey := tc.pr.getIdempotencyKey(tc.workerID, iterationCount)
+	invokeOptionsJSON := ""
+	if tc.pr.cfg.InvokeOptions != nil {
+		b, err := json.Marshal(tc.pr.cfg.InvokeOptions)
+		if err == nil {
+			invokeOptionsJSON = fmt.Sprintf(",\n		 \"options\": %s", b)
+		}
+	}
+	payload := fmt.Sprintf(`{
+		"location": {
+			"address": "%s"
+		},
+		"method": {
+			"name": "transfer",
+			"params": [
+				{
+					"name": "to",
+					"schema": {
+						"type": "string",
+						"details": {
+							"type": "address"
+						}
+					}
+				},
+				{
+					"name": "amount",
+					"schema": {
+						"type": "integer",
+						"details": {
+							"type": "uint256"
+						}
+					}
+				}
+			],
+			"returns": [
+				{
+					"name": "",
+					"schema": {
+						"type": "boolean",
+						"details": {
+							"type": "bool"
+						}
+					}
+				}
+			]
+		},
+		"input": {
+			"to": "0x2989c0f1f7b9e861f521dbfc4069b74ab0ce12a2",
+			"amount": 1
+		},
+		"key": "%s",
+		"idempotencyKey": "%s"%s
+	}`, tc.pr.cfg.ContractOptions.Address, tc.pr.cfg.SigningKey, idempotencyKey, invokeOptionsJSON)
+	var resContractCall map[string]interface{}
+	var resError fftypes.RESTError
+	fullPath, err := url.JoinPath(tc.pr.client.BaseURL, tc.pr.cfg.FFNamespacePath, "contracts/invoke")
+	if err != nil {
+		return "", err
+	}
+	res, err := tc.pr.client.R().
+		SetHeaders(map[string]string{
+			"Accept":       "application/json",
+			"Content-Type": "application/json",
+		}).
+		SetBody([]byte(payload)).
+		SetResult(&resContractCall).
+		SetError(&resError).
+		Post(fullPath)
+	id := resContractCall["id"].(string)
+	if err != nil || res.IsError() {
+		if res.StatusCode() == 409 {
+			log.Warnf("Request already received by FireFly: %+v", &resError)
+		} else {
+			return "", fmt.Errorf("Error invoking contract [%d]: %s (%+v)", resStatus(res), err, &resError)
+		}
+	}
+	log.Infof("Submitted token transfer: %s", id)
+
+	return id, nil
+}

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -1332,8 +1332,6 @@ func (pr *perfRunner) premintERC20Tokens(nodeURL string, contractAddress string,
 	}
 	id := responseBody["id"].(string)
 	log.Infof("Submitted minting request of %d tokens for address %s of ERC20 contract at %s, firefly request id: %s", amount, signingKeyAddress, contractAddress, id)
-	pr.listenerIDsForNodes[nodeURL] = append(pr.listenerIDsForNodes[nodeURL], id)
-
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -102,8 +102,8 @@ func (hs *HttpServer) gracefulShutdown() {
 }
 
 func (hs *HttpServer) Shutdown() {
-	log.Warn("Server shutting down in 30s")
-	time.Sleep(30 * time.Second)
+	log.Warn("Server shutting down in 5s")
+	time.Sleep(5 * time.Second)
 
 	// We received an interrupt signal, shut down.
 	if err := hs.srv.Shutdown(context.Background()); err != nil {


### PR DESCRIPTION
Adding support for a standard erc20 smart contract. This introduces a prepare task of test cases, which currently is only applicable to erc20 test case. The prepare behavior for erc20 is to pre-mint sufficient tokens that can be used for testing the transfer call