### PR TITLE
Adding control for submission rate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ There are various options for creating your own customized tests. A full list of
   - All values default to `0` which has the effect of not limiting the rate of the test.
   - The test will allow at most `startRate` actions to happen per second. Over the period of `rateRampUpTime` seconds the allowed rate will increase linearly until `endRate` actions per seconds are reached. At this point the test will continue at `endRate` actions per second until the test finishes.
   - If `startRate` is the only value that is set, the test will run at that rate for the entire test.
-- Waiting for mint transactions to be confirmed before doing the next one
+- Waiting for events to be confirmed before doing the next submission
   - See `noWaitSubmission` (defaults to `false`).
   - When set to `true` each worker routine will perform its action (e.g. minting a token) and wait for confirmation of that event before doing its next action.
+  - `maxSubmissionsPerSecond` can be used to control the maximum number of submissions per second to avoid overloading the system under test.
 - Setting the features of a token being tested
   - See `supportsData` and `supportsURI` attributes of a test instance.
   - `supportsData` defaults to `true` since the sample token contract used by FireFly supports minting tokens with data. When set to `true` the message included in the mint transaction will include the ID of the worker routine and used to correlate received confirmation events.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -217,6 +217,7 @@ func generateRunnerConfigFromInstance(instance *conf.InstanceConfig, perfConfig 
 	runnerConfig.LogLevel = perfConfig.LogLevel
 	runnerConfig.SkipMintConfirmations = instance.SkipMintConfirmations
 	runnerConfig.NoWaitSubmission = instance.NoWaitSubmission
+	runnerConfig.MaxSubmissionsPerSecond = instance.MaxSubmissionsPerSecond
 	runnerConfig.Length = instance.Length
 	runnerConfig.Daemon = perfConfig.Daemon
 	runnerConfig.LogEvents = perfConfig.LogEvents

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -54,6 +54,7 @@ type RunnerConfig struct {
 	RampLength                time.Duration
 	SkipMintConfirmations     bool // deprecated
 	NoWaitSubmission          bool
+	MaxSubmissionsPerSecond   int
 	SubscriptionCoreOptions   *core.SubscriptionCoreOptions
 }
 
@@ -87,6 +88,7 @@ type InstanceConfig struct {
 	RampLength                time.Duration                 `json:"rampLength,omitempty" yaml:"rampLength,omitempty"`
 	SkipMintConfirmations     bool                          `json:"skipMintConfirmations" yaml:"skipMintConfirmations"` // deprecated
 	NoWaitSubmission          bool                          `json:"noWaitSubmission" yaml:"noWaitSubmission"`
+	MaxSubmissionsPerSecond   int                           `json:"maxSubmissionsPerSecond" yaml:"maxSubmissionsPerSecond"`
 	DelinquentAction          string                        `json:"delinquentAction,omitempty" yaml:"delinquentAction,omitempty"`
 	PerWorkerSigningKeyPrefix string                        `json:"perWorkerSigningKeyPrefix,omitempty" yaml:"perWorkerSigningKeyPrefix,omitempty"`
 	SubscriptionCoreOptions   *core.SubscriptionCoreOptions `json:"subscriptionOptions,omitempty" yaml:"subscriptionOptions,omitempty"`

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -50,9 +50,7 @@ const workerPrefix = "worker-"
 const preparePrefix = "prep-"
 
 var mutex = &sync.Mutex{}
-var limiter *rate.Limiter
 var TRANSPORT_TYPE = "websockets"
-var wsReadAhead = uint16(50)
 
 var METRICS_NAMESPACE = "ffperf"
 var METRICS_SUBSYSTEM = "runner"

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -199,7 +199,6 @@ type perfRunner struct {
 	subscriptionIDsForNodes    map[string][]string
 	daemon                     bool
 	sender                     string
-	maxSubmissionsPerSecond    int
 	totalWorkers               int
 }
 
@@ -550,14 +549,14 @@ perfLoop:
 			break perfLoop
 		}
 
-		if pr.maxSubmissionsPerSecond > 0 {
+		if pr.cfg.MaxSubmissionsPerSecond > 0 {
 			// control send rate
 			secondTicker := time.NewTicker(1 * time.Second)
 			select {
 			case <-signalCh:
 				break perfLoop
 			case <-secondTicker.C:
-				for j := 0; j < pr.maxSubmissionsPerSecond; j++ {
+				for j := 0; j < pr.cfg.MaxSubmissionsPerSecond; j++ {
 					pr.bfr <- j
 				}
 				i++


### PR DESCRIPTION
Currently in no wait submission mode, firefly-perf-cli submit test requests as fast as it possibly can. This can cause undesired load on the targeting system under test.

This PR introduces `maxSubmissionsPerSecond` setting in the configuration to add control for a more stable submission pattern.