### PR TITLE
fix goreleaser build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: 2
+
 before:
   hooks:
     - go mod tidy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_VERSION=canary
 
-FROM golang:1.17-alpine3.15 as builder
+FROM golang:1.21.12-alpine as builder
 
 RUN apk add make gcc build-base curl git
 WORKDIR /firefly-perf-cli


### PR DESCRIPTION
- update go version to 1.21 so the `toolchain` directive works 
- specify `version: 2` in `.goreleaser.yaml` to fix config warning