### PR TITLE
fixing double counting

### DIFF
--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -1279,7 +1279,6 @@ func (pr *perfRunner) recordCompletedAction() {
 	if pr.ramping() {
 		_ = atomic.AddInt64(&pr.summary.rampSummary, 1) // increment atomically
 	} else {
-		pr.summary.totalSummary++
 		_ = atomic.AddInt64(&pr.summary.totalSummary, 1) // increment atomically
 	}
 }


### PR DESCRIPTION
fixing a bug that the perf-cli is double counting TPS